### PR TITLE
sort search, modal location, remove irrelevant rules.

### DIFF
--- a/catch-you-later/general.html
+++ b/catch-you-later/general.html
@@ -55,6 +55,6 @@
     </div>
 
     <script type="module" src="/src/backend/main.ts"></script>
-    <script type="module" src="/src/backend/ModalInfoPanelGeneral.js"></script>
+    <script type="module" src="/src/backend/modal-info-panel-general.ts"></script>
   </body>
 </html>

--- a/catch-you-later/index.html
+++ b/catch-you-later/index.html
@@ -60,6 +60,8 @@
         <p><strong>Typ:</strong> <span class="modal-type-indicator"></span><span id="modalRuleType"></span></p>
         <p><strong>Beskrivning:</strong></p>
         <p id="modalRuleDescription"></p>
+        <p><strong id="modalLocationTitle">Plats:</strong></p>
+        <p id="modalLocationList"></p>
       </div>
     </div>
     <!-- End Modal Structure -->

--- a/catch-you-later/src/backend/display-fishing-regulations.ts
+++ b/catch-you-later/src/backend/display-fishing-regulations.ts
@@ -18,8 +18,6 @@ export function displayFormattedFishingRegulations(
   // Group the rules by species and location
   const grouped = groupFormattedRulesBySpeciesAndLocation(filteredData);
 
-
-
   container.innerHTML = [...grouped.entries()]
       .map(([_, rules]) => {
         const { species, location } = rules[0];

--- a/catch-you-later/src/backend/display-fishing-regulations.ts
+++ b/catch-you-later/src/backend/display-fishing-regulations.ts
@@ -45,7 +45,7 @@ export function displayFormattedFishingRegulations(
                     return `Övrigt`; // Display "Övrigt" as plain text
                   }
 
-                  return `<a href="https://sv.wikipedia.org/wiki/${encodeURIComponent(baseName)}" target="_blank">${baseName}</a> ${parenthesis}`;
+                  return `<a href="https://sv.wikipedia.org/wiki/${encodeURIComponent(baseName)}" target="_blank">${baseName}</a>${parenthesis ? ' ' + parenthesis : ''}`;
                 })
                 .join(', ')
             : 'Ingen specificerad';
@@ -58,7 +58,7 @@ export function displayFormattedFishingRegulations(
        location-ids="${location.map(l => l.id).join(',')}">
         <div class="rule-row">
           <div class="rule-column">
-            <div><strong>Art</strong><br></div>
+            <div><strong>${speciesLinks.includes(',') ? 'Arter' : 'Art'}</strong><br></div>
             <div>${speciesLinks}</div>
           </div>
           <div class="rule-column">

--- a/catch-you-later/src/backend/display-fishing-regulations.ts
+++ b/catch-you-later/src/backend/display-fishing-regulations.ts
@@ -56,8 +56,7 @@ export function displayFormattedFishingRegulations(
             : 'Ingen specificerad';
         return `
        <div class="rule-card" 
-       location-ids="${location.map(l => l.id).join(',')}" 
-       data-location='${JSON.stringify(location)}'>
+       location-ids="${location.map(l => l.id).join(',')}">
         <div class="rule-row">
           <div class="rule-column">
             <div><strong>Art</strong><br></div>
@@ -119,6 +118,13 @@ function buttonClickListener(){
     btn.addEventListener('click', (e) => {
       const el = e.currentTarget as HTMLButtonElement;
 
+      // Hitta det närmaste "rule-card"-elementet
+      const ruleCardElement = el.closest('.rule-card');
+      if (!ruleCardElement) {
+        console.error('Rule card not found for the clicked button.');
+        return;
+      }
+
       const text = decodeURIComponent(el.dataset.ruleText || '');
       const type = el.dataset.ruleType || 'Okänd'; // Default to 'Okänd'
       const ruleNumberText = el.textContent?.trim() || 'Regel'; // Use button text for title
@@ -128,24 +134,14 @@ function buttonClickListener(){
       modalRuleType.textContent = type;
       modalRuleDescription.textContent = text;
 
-      if (!modalLocationList) {
-        console.error('Elementet modalLocationList hittades inte i DOM!');
-        return;
+      const locationNames = ruleCardElement.querySelector('.rule-column p')?.textContent || 'Ingen specificerad';
+
+      if (modalLocationList) {
+        modalLocationList.textContent = locationNames;
       }
-
-      // Fetch and parse location data
-      const ruleCard = el.closest('.rule-card');
-      const locationData = ruleCard?.getAttribute('data-location');
-      console.log('Fetched data-location:', locationData);
-      const locations = locationData ? JSON.parse(locationData) : [];
-      console.log("location", locations)
-      // Populate location list
-      modalLocationList.textContent = locations
-      .map((loc: { name: string; id: string }) => loc.name)
-      .join(', ');
-
+  
       if (modalLocationTitle) {
-        modalLocationTitle.textContent = locations.length > 1 ? 'Platser:' : 'Plats:';
+        modalLocationTitle.textContent = locationNames.includes(',') ? 'Platser:' : 'Plats:';
       }
 
       // Set indicator color

--- a/catch-you-later/src/backend/display-fishing-regulations.ts
+++ b/catch-you-later/src/backend/display-fishing-regulations.ts
@@ -54,9 +54,10 @@ export function displayFormattedFishingRegulations(
         const locationNames = location.length > 0
             ? location.map(l => l.name).join(', ')
             : 'Ingen specificerad';
-
         return `
-      <div class="rule-card" location-ids="${location.map(l => l.id).join(',')}">
+       <div class="rule-card" 
+       location-ids="${location.map(l => l.id).join(',')}" 
+       data-location='${JSON.stringify(location)}'>
         <div class="rule-row">
           <div class="rule-column">
             <div><strong>Art</strong><br></div>
@@ -106,6 +107,8 @@ function buttonClickListener(){
   const modalRuleType = document.getElementById('modalRuleType');
   const modalRuleDescription = document.getElementById('modalRuleDescription');
   const modalTypeIndicator = document.querySelector('.modal-type-indicator');
+  const modalLocationList = document.getElementById("modalLocationList")
+  const modalLocationTitle = document.getElementById("modalLocationTitle");
 
   if (!modal || !modalOverlay || !modalTitle || !modalRuleType || !modalRuleDescription || !modalTypeIndicator) {
     console.error('Modal elements not found!');
@@ -124,6 +127,26 @@ function buttonClickListener(){
       modalTitle.textContent = ruleNumberText;
       modalRuleType.textContent = type;
       modalRuleDescription.textContent = text;
+
+      if (!modalLocationList) {
+        console.error('Elementet modalLocationList hittades inte i DOM!');
+        return;
+      }
+
+      // Fetch and parse location data
+      const ruleCard = el.closest('.rule-card');
+      const locationData = ruleCard?.getAttribute('data-location');
+      console.log('Fetched data-location:', locationData);
+      const locations = locationData ? JSON.parse(locationData) : [];
+      console.log("location", locations)
+      // Populate location list
+      modalLocationList.textContent = locations
+      .map((loc: { name: string; id: string }) => loc.name)
+      .join(', ');
+
+      if (modalLocationTitle) {
+        modalLocationTitle.textContent = locations.length > 1 ? 'Platser:' : 'Plats:';
+      }
 
       // Set indicator color
       modalTypeIndicator.className = 'modal-type-indicator'; // Reset classes

--- a/catch-you-later/src/backend/display-fishing-regulations.ts
+++ b/catch-you-later/src/backend/display-fishing-regulations.ts
@@ -1,5 +1,5 @@
 import type { FormattedFishingRule } from './fetch-fishing-regulations.ts';
-import { groupFormattedRulesBySpeciesAndLocation, removeGeneralRules } from './helpers';
+import { groupFormattedRulesBySpeciesAndLocation, removeGeneralRules, removeRulesWithText } from './helpers';
 
 /**Display fishing rules as cards and rule buttons */
 export function displayFormattedFishingRegulations(
@@ -12,8 +12,9 @@ export function displayFormattedFishingRegulations(
     return;
   }
 
-  // Remove "Allmän regel" rules
-  const filteredData = removeGeneralRules(data);
+  // Remove "Allmän regel" rules, and rules with "regel" in the text
+  const noGeneralRules = removeGeneralRules(data);
+  const filteredData = removeRulesWithText("regel", noGeneralRules);
 
   // Group the rules by species and location
   const grouped = groupFormattedRulesBySpeciesAndLocation(filteredData);
@@ -61,7 +62,7 @@ export function displayFormattedFishingRegulations(
             <div>${speciesLinks}</div>
           </div>
           <div class="rule-column">
-            <div><strong>Plats</strong></div>
+            <div><strong>${locationNames.includes(',') ? 'Platser' : 'Plats'}</strong></div>
             <div><p>${locationNames}</p></div>
           </div>
           <div class="small-rule-column"></div>
@@ -116,7 +117,7 @@ function buttonClickListener(){
     btn.addEventListener('click', (e) => {
       const el = e.currentTarget as HTMLButtonElement;
 
-      // Hitta det närmaste "rule-card"-elementet
+      // Find closest rule-card element
       const ruleCardElement = el.closest('.rule-card');
       if (!ruleCardElement) {
         console.error('Rule card not found for the clicked button.');
@@ -132,14 +133,14 @@ function buttonClickListener(){
       modalRuleType.textContent = type;
       modalRuleDescription.textContent = text;
 
-      const locationNames = ruleCardElement.querySelector('.rule-column p')?.textContent || 'Ingen specificerad';
+      const locationNames = ruleCardElement.querySelector('.rule-column p')?.textContent ?? 'Ingen specificerad';
 
       if (modalLocationList) {
         modalLocationList.textContent = locationNames;
       }
   
       if (modalLocationTitle) {
-        modalLocationTitle.textContent = locationNames.includes(',') ? 'Platser:' : 'Plats:';
+        modalLocationTitle.textContent = locationNames.includes(',') ? 'Platser:' : 'Plats:'; // Singular or plural based on the number of locations
       }
 
       // Set indicator color

--- a/catch-you-later/src/backend/helpers.ts
+++ b/catch-you-later/src/backend/helpers.ts
@@ -1,6 +1,6 @@
 import type { FormattedFishingRule } from './fetch-fishing-regulations.ts';
 
-/** Group the rules by species and location, each specie location pair gives a set of rules */
+/** Group the rules by species and location, each specie location pair gives a set of rules, order based on priority score */
 export function groupFormattedRulesBySpeciesAndLocation(
   data: (FormattedFishingRule & { _score?: number })[]
 ): Map<string, FormattedFishingRule[]> {
@@ -12,7 +12,7 @@ export function groupFormattedRulesBySpeciesAndLocation(
     const key = `${rule.species}::${rule.location.map(loc => loc.id).sort().join(',')}`;
     if (!tempGrouped.has(key)) {
       tempGrouped.set(key, []);
-      scoreMap.set(key, rule._score || 0); // First rule score = group score 
+      scoreMap.set(key, rule._score ?? 0); // First rule score = group score 
     }
 
     tempGrouped.get(key)!.push(rule);
@@ -37,7 +37,12 @@ export function groupFormattedRulesBySpeciesAndLocation(
 
 /** Filter out the general rules from the data, i.e ones with type "Allmän regel"*/
 export function removeGeneralRules(data: FormattedFishingRule[]): FormattedFishingRule[] {
-  return data.filter(rule => rule.type !== 'Allmän regel' &&  !rule.targetGroup.includes('OTHER') && !rule.text.toLocaleLowerCase().includes("regel"));
+  return data.filter(rule => rule.type !== 'Allmän regel' &&  !rule.targetGroup.includes('OTHER'));
+}
+
+/** Filter out the rules with a specific text, e.g. "Regel" */
+export function removeRulesWithText(textToFilterOut : string, data: FormattedFishingRule[]): FormattedFishingRule[] {
+  return data.filter(rule => !rule.text.toLocaleLowerCase().includes(textToFilterOut.toLocaleLowerCase()));
 }
 
 /** gives the rules with type "Allmän regel"*/

--- a/catch-you-later/src/backend/helpers.ts
+++ b/catch-you-later/src/backend/helpers.ts
@@ -2,25 +2,38 @@ import type { FormattedFishingRule } from './fetch-fishing-regulations.ts';
 
 /** Group the rules by species and location, each specie location pair gives a set of rules */
 export function groupFormattedRulesBySpeciesAndLocation(
-  data: FormattedFishingRule[]
+  data: (FormattedFishingRule & { _score?: number })[]
 ): Map<string, FormattedFishingRule[]> {
-  const grouped = new Map<string, FormattedFishingRule[]>();
+  const tempGrouped = new Map<string, FormattedFishingRule[]>();
+  const scoreMap = new Map<string, number>();
 
+  // Process each rule and group them by species and location temporarily
   for (const rule of data) {
-    const key = `${rule.species}::${rule.location
-      .map(loc => loc.id)
-      .sort()
-      .join(', ')}`;
-
-    if (!grouped.has(key)) {
-      grouped.set(key, []);
+    const key = `${rule.species}::${rule.location.map(loc => loc.id).sort().join(',')}`;
+    if (!tempGrouped.has(key)) {
+      tempGrouped.set(key, []);
+      scoreMap.set(key, rule._score || 0); // First rule score = group score 
     }
 
-    grouped.get(key)!.push(rule);
+    tempGrouped.get(key)!.push(rule);
   }
 
-  return grouped;
+  // Sort group based on score
+  const sortedEntries = [...tempGrouped.entries()].sort((a, b) => {
+    const scoreA = scoreMap.get(a[0]) ?? 0;
+    const scoreB = scoreMap.get(b[0]) ?? 0;
+    return scoreB - scoreA;
+  });
+
+  // Create a new Map with the sorted entries
+  const orderedGrouped = new Map<string, FormattedFishingRule[]>();
+  for (const [key, rules] of sortedEntries) {
+    orderedGrouped.set(key, rules);
+  }
+
+  return orderedGrouped;
 }
+
 
 /** Filter out the general rules from the data, i.e ones with type "Allmän regel"*/
 export function removeGeneralRules(data: FormattedFishingRule[]): FormattedFishingRule[] {

--- a/catch-you-later/src/backend/helpers.ts
+++ b/catch-you-later/src/backend/helpers.ts
@@ -24,7 +24,7 @@ export function groupFormattedRulesBySpeciesAndLocation(
 
 /** Filter out the general rules from the data, i.e ones with type "Allmän regel"*/
 export function removeGeneralRules(data: FormattedFishingRule[]): FormattedFishingRule[] {
-  return data.filter(rule => rule.type !== 'Allmän regel' &&  !rule.targetGroup.includes('OTHER'));
+  return data.filter(rule => rule.type !== 'Allmän regel' &&  !rule.targetGroup.includes('OTHER') && !rule.text.toLocaleLowerCase().includes("regel"));
 }
 
 /** gives the rules with type "Allmän regel"*/

--- a/catch-you-later/src/backend/main.ts
+++ b/catch-you-later/src/backend/main.ts
@@ -8,7 +8,7 @@ import { updatePolygons } from './map-handler.ts';
 
 /** Loads the fishing regulation cards and searchbar */
 async function loadData() {
-  const data = await fetchAllFishingRegulations();
+  let data = await fetchAllFishingRegulations();
 
   // Display all regulations initially
   displayFormattedFishingRegulations(data, '#regulations');

--- a/catch-you-later/src/backend/main.ts
+++ b/catch-you-later/src/backend/main.ts
@@ -8,7 +8,7 @@ import { updatePolygons } from './map-handler.ts';
 
 /** Loads the fishing regulation cards and searchbar */
 async function loadData() {
-  let data = await fetchAllFishingRegulations();
+  const data = await fetchAllFishingRegulations();
 
   // Display all regulations initially
   displayFormattedFishingRegulations(data, '#regulations');

--- a/catch-you-later/src/backend/search-handler.ts
+++ b/catch-you-later/src/backend/search-handler.ts
@@ -18,26 +18,73 @@ export function setupSearchBar(
   searchBar.addEventListener('input', async () => {
     const query = searchBar.value.toLocaleLowerCase();
 
-    let filteredRegulations = regulations;
-
-    if (query) {
-      filteredRegulations = regulations.filter(regulation => {
-        return (
-          regulation.species.some(specie =>
-            specie.toLowerCase().includes(query)
-          ) ||
-          regulation.location.some(location =>
-            location.name.toLowerCase().includes(query)
-          ) ||
-          regulation.text.toLocaleLowerCase().includes(query)
-        );
-      });
-    }
-
+    let prioritizedAndFilteredRegulations = prioritizeAndFilterQuery(query, regulations);
+    
     // Update the displayed regulations
-    displayFormattedFishingRegulations(filteredRegulations, containerId);
+    displayFormattedFishingRegulations(prioritizedAndFilteredRegulations, containerId);
 
     // Update the polygons on the map
-    await updatePolygons(map, filteredRegulations);
+    await updatePolygons(map, prioritizedAndFilteredRegulations);
   });
+}
+
+/** Function to prioritize and filter the search results based on the query.
+ * * @param query - The search query entered by the user.
+ * * @param regulations - The list of fishing regulations to filter.
+ * * @returns - A new array of filtered and prioritized (sorted) regulations.
+ * - exact match get higher score than partial match,
+ * - species get higher score than location name,
+ * - location name get higher score than rule text.
+*/
+function prioritizeAndFilterQuery(query : string, regulations: FormattedFishingRule[]) {
+  let filteredRegulations = regulations;
+  if (query) {
+    const queryLower = query.toLowerCase();
+    const queryRegex = new RegExp(`\\b${queryLower}\\b`, 'i');
+  
+    filteredRegulations = regulations
+      .map(regulation => {
+        let score = 0;
+  
+        // Specie name
+        for (const specie of regulation.species) {
+          const lower = specie.toLowerCase();
+          if (queryRegex.test(lower)) {
+            score += 10; // exact match
+            console.log("exact specie match", regulation.text, score);
+          } else if (lower.includes(queryLower)) {
+            score += 3; // partial match
+            console.log("partial specie match", regulation.text, score);
+          }
+        }
+  
+        // Location name
+        for (const loc of regulation.location) {
+          const lower = loc.name.toLowerCase();
+          if (queryRegex.test(lower)) {
+            score += 6; // exact match
+            console.log("exact loc match", regulation.text, score);
+          } else if (lower.includes(queryLower)) {
+            score += 2; // partial match
+            console.log("partial loc match", regulation.text, score);
+          }
+        }
+  
+        // Rule text
+        const textLower = regulation.text.toLowerCase();
+        if (queryRegex.test(textLower)) {
+          score += 4; // exact match
+          console.log("exact text match", regulation.text, score);
+        } else if (textLower.includes(queryLower)) {
+          score += 1; // partial match
+          console.log("partial text match", regulation.text, score);
+        }
+  
+        return { ...regulation, _score: score };
+      })
+      .filter(r => r._score > 0) // Filter out regulations with no score
+      .sort((a, b) => b._score - a._score); // Sort by score in descending order
+  }
+
+  return filteredRegulations;
 }

--- a/catch-you-later/src/backend/search-handler.ts
+++ b/catch-you-later/src/backend/search-handler.ts
@@ -18,6 +18,7 @@ export function setupSearchBar(
   searchBar.addEventListener('input', async () => {
     const query = searchBar.value.toLocaleLowerCase();
 
+    // Sort and filter the regulations based on the query
     let prioritizedAndFilteredRegulations = prioritizeAndFilterQuery(query, regulations);
     
     // Update the displayed regulations
@@ -28,7 +29,7 @@ export function setupSearchBar(
   });
 }
 
-/** Function to prioritize and filter the search results based on the query.
+/** Function to prioritize/sort and filter the search results based on the query.
  * * @param query - The search query entered by the user.
  * * @param regulations - The list of fishing regulations to filter.
  * * @returns - A new array of filtered and prioritized (sorted) regulations.
@@ -51,10 +52,8 @@ function prioritizeAndFilterQuery(query : string, regulations: FormattedFishingR
           const lower = specie.toLowerCase();
           if (queryRegex.test(lower)) {
             score += 10; // exact match
-            console.log("exact specie match", regulation.text, score);
           } else if (lower.includes(queryLower)) {
             score += 3; // partial match
-            console.log("partial specie match", regulation.text, score);
           }
         }
   
@@ -63,10 +62,8 @@ function prioritizeAndFilterQuery(query : string, regulations: FormattedFishingR
           const lower = loc.name.toLowerCase();
           if (queryRegex.test(lower)) {
             score += 6; // exact match
-            console.log("exact loc match", regulation.text, score);
           } else if (lower.includes(queryLower)) {
             score += 2; // partial match
-            console.log("partial loc match", regulation.text, score);
           }
         }
   
@@ -74,10 +71,8 @@ function prioritizeAndFilterQuery(query : string, regulations: FormattedFishingR
         const textLower = regulation.text.toLowerCase();
         if (queryRegex.test(textLower)) {
           score += 4; // exact match
-          console.log("exact text match", regulation.text, score);
         } else if (textLower.includes(queryLower)) {
           score += 1; // partial match
-          console.log("partial text match", regulation.text, score);
         }
   
         return { ...regulation, _score: score };


### PR DESCRIPTION
Lade till:
- Plats i modal panelen.
- En funktion för att ta bort irrelevanta regler, det verkar som att det är de som innehöll ordet "Regel"
- En prioriteringsmetod i kombination med sökningen. Jag tror inte denna är helt perfekt, egentligen hade det nog varit bra att gruppera innan detta görs men det kändes som en stor omstrukturering, så nu får grupperingsmetoden ta hänsyn till score innan ordningen skickas tbx. Titta gärna på det och ge förslag om det inte känns bra.

kanske gjorde något annat småfix med 